### PR TITLE
Transpose and aggregate query.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,6 @@
 {
   "koopProviderRedshiftAnalytics": {
-    "dimensions": ["day"],
+    "dimensions": ["day", "a_hostname", "a_org"],
     "timeDimensions": ["day"],
     "metrics": ["pageViews", "sessions", "avgSessionDuration"],
     "defaultTimeRangeStart": {

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -11,6 +11,7 @@ const {
 } = require('config')
 const camelCase = require('./camel-case')
 const createCompleteTimeseries = require('./create-complete-timeseries')
+const transposeAndAggregateByDimensions = require('./transpose-and-aggregate-by-dimensions')
 
 const db = require('knex')({
   client: 'pg',
@@ -25,10 +26,10 @@ const db = require('knex')({
     const {
       timeseries,
       metric,
-      startDate,
-      endDate,
-      interval,
-      snakeCases
+      timeDimension,
+      dimensions,
+      snakeCases,
+      transposeAndAggregate
     } = queryContext
     let postProcessed
 
@@ -37,7 +38,11 @@ const db = require('knex')({
     }
 
     if (timeseries) {
-      postProcessed = createCompleteTimeseries({ data: postProcessed || data, metric, startDate, endDate, interval })
+      postProcessed = createCompleteTimeseries({ data: postProcessed || data, metric, ...timeseries })
+    }
+
+    if (transposeAndAggregate) {
+      postProcessed = transposeAndAggregateByDimensions({ data: postProcessed || data, metric, timeDimension, dimensions })
     }
 
     return postProcessed || data

--- a/lib/db/transpose-and-aggregate-by-dimensions.js
+++ b/lib/db/transpose-and-aggregate-by-dimensions.js
@@ -1,0 +1,83 @@
+const _ = require('lodash')
+
+module.exports = function (params) {
+  const { data, metric, dimensions, timeDimension } = params
+
+  const { transpositionDimension, aggregationDimension } = parseDimensions(dimensions, timeDimension)
+
+  const transposedData = transposeAndAggregate({ data, metric, transpositionDimension, aggregationDimension })
+
+  const placeholders = createZeroValuePlaceholdersForTranpose(transposedData)
+
+  return mergePlaceholders(transposedData, placeholders)
+}
+
+function parseDimensions (dimensions, timeDimension) {
+  const [transpositionDimension, aggregationDimension] = dimensions.map(dimension => {
+    if (dimension === timeDimension) {
+      return 'timestamp'
+    }
+    return dimension
+  })
+
+  return { transpositionDimension, aggregationDimension }
+}
+
+function transposeAndAggregate (params) {
+  const {
+    data,
+    metric,
+    transpositionDimension,
+    aggregationDimension
+  } = params
+  return _.chain(data)
+    .reduce((store, record) => {
+      const transposedRecord = transposeRecord({ record, metric, aggregationDimension, transpositionDimension })
+      if (!transposedRecord) return store
+      return updateStore({ store, aggregationDimension, record: transposedRecord })
+    }, {})
+    .values()
+    .value()
+}
+
+function transposeRecord ({ record, metric, aggregationDimension, transpositionDimension }) {
+  if (!record[transpositionDimension] && record[transpositionDimension] !== '') return
+
+  const transposedKey = record[transpositionDimension] === '' ? 'emptyString' : record[transpositionDimension]
+
+  return {
+    [aggregationDimension]: record[aggregationDimension],
+    [transposedKey]: Number(record[metric])
+  }
+}
+
+function updateStore ({ store, aggregationDimension, record }) {
+  const aggregationKey = record[aggregationDimension]
+  const currentValue = _.get(store, [`${aggregationKey}`], {})
+  _.set(store, [`${aggregationKey}`], { ...currentValue, ...record })
+  return store
+}
+
+function createZeroValuePlaceholdersForTranpose (transposedData) {
+  return _.chain(transposedData)
+    .map((record) => {
+      return _.keys(record)
+    })
+    .flatten()
+    .filter(key => {
+      return key !== 'timestamp' && key !== 'undefined'
+    })
+    .map(key => {
+      return [key, 0]
+    })
+    .fromPairs()
+    .value()
+}
+
+function mergePlaceholders (transposedData, placeholders) {
+  return _.chain(transposedData)
+    .map(record => {
+      return { ...placeholders, ...record }
+    })
+    .value()
+}

--- a/lib/db/transpose-and-aggregate-by-dimensions.js
+++ b/lib/db/transpose-and-aggregate-by-dimensions.js
@@ -53,8 +53,8 @@ function transposeRecord ({ record, metric, aggregationDimension, transpositionD
 
 function updateStore ({ store, aggregationDimension, record }) {
   const aggregationKey = record[aggregationDimension]
-  const currentValue = _.get(store, [`${aggregationKey}`], {})
-  _.set(store, [`${aggregationKey}`], { ...currentValue, ...record })
+  const currentValue = _.get(store, [aggregationKey], {})
+  _.set(store, [aggregationKey], { ...currentValue, ...record })
   return store
 }
 

--- a/lib/query/event.js
+++ b/lib/query/event.js
@@ -7,7 +7,6 @@ const {
         event: eventSource
       } = {}
     } = {},
-    timeDimensions: TIME_DIMENSIONS,
     eventLookup
   }
 } = require('config')
@@ -19,53 +18,73 @@ const {
   timestampColumn
 } = eventSource || defaultSource
 
-const isDimensionTime = (dimension) => TIME_DIMENSIONS.includes(dimension)
-
 function buildEventQuery (params) {
-  const { dimension } = params
+  const {
+    dimensions = [],
+    timeDimension
+  } = params
 
-  if (isDimensionTime(dimension)) {
+  if (timeDimension) {
     return buildTimeDimensionedEventCountQuery(params)
   }
 
-  if (dimension) {
+  if (dimensions.length) {
     return buildDimensionedEventCountQuery(params)
   }
 
   return buildEventCountQuery(params)
 }
 
-function buildTimeDimensionedEventCountQuery ({ metric, dimension, where, startDate, endDate }) {
+function buildTimeDimensionedEventCountQuery (params) {
+  const {
+    metric,
+    dimensions,
+    timeDimension,
+    nonTimeDimensions,
+    where,
+    startDate,
+    endDate,
+    transposeAndAggregate
+  } = params
+  const rawSelect = [`DATE_TRUNC('${timeDimension}', ${timestampColumn} ) AS timestamp`].concat(nonTimeDimensions).join(', ')
+  const rawGroupBy = [`DATE_TRUNC('${timeDimension}', ${timestampColumn} )`].concat(nonTimeDimensions).join(', ')
   const metricAlias = getMetricAlias(metric)
-  return db.select(db.raw(`DATE_TRUNC('${dimension}', ${timestampColumn} ) AS timestamp`))
+  return db.select(db.raw(rawSelect))
     .count(`${eventColumn} AS ${metricAlias}`)
     .withSchema(schema)
     .from(table)
     .where(eventColumn, '=', eventLookup[metric])
     .andWhereRaw(where)
-    .groupByRaw(`DATE_TRUNC('${dimension}', ${timestampColumn} )`)
-    .orderByRaw(`DATE_TRUNC('${dimension}', ${timestampColumn} )`)
+    .groupByRaw(rawGroupBy)
+    .orderByRaw(`DATE_TRUNC('${timeDimension}', ${timestampColumn} )`)
     .queryContext({
-      timeseries: true,
-      startDate,
-      endDate,
-      interval: dimension,
+      timeseries: {
+        startDate,
+        endDate,
+        interval: timeDimension
+      },
       metric,
-      snakeCases: metric === metricAlias ? undefined : [metricAlias]
+      snakeCases: metric === metricAlias ? undefined : [metricAlias],
+      transposeAndAggregate,
+      dimensions,
+      timeDimension
     })
 }
 
-function buildDimensionedEventCountQuery ({ metric, dimension, where }) {
+function buildDimensionedEventCountQuery ({ metric, dimensions, where, transposeAndAggregate }) {
   const metricAlias = getMetricAlias(metric)
-  return db.select(dimension)
+  return db.select(...dimensions)
     .count(`${eventColumn} AS ${metricAlias}`)
     .withSchema(schema)
     .from(table)
     .where(eventColumn, '=', eventLookup[metric])
     .andWhereRaw(where)
-    .groupBy(dimension)
+    .groupBy(...dimensions)
     .queryContext({
-      snakeCases: metric === metricAlias ? undefined : [metricAlias]
+      snakeCases: metric === metricAlias ? undefined : [metricAlias],
+      transposeAndAggregate,
+      dimensions,
+      metric
     })
 }
 

--- a/lib/query/session-duration.js
+++ b/lib/query/session-duration.js
@@ -5,8 +5,7 @@ const {
         defaultSource = {},
         session: sessionSource
       } = {}
-    } = {},
-    timeDimensions: TIME_DIMENSIONS
+    } = {}
   }
 } = require('config')
 const db = require('../db')
@@ -17,62 +16,79 @@ const {
   timestampColumn
 } = sessionSource || defaultSource
 
-const isDimensionTime = (dimension) => TIME_DIMENSIONS.includes(dimension)
-
 function buildSessionDurationQuery (params = {}) {
   const {
-    dimension
+    dimensions = [],
+    timeDimension
   } = params
 
-  if (isDimensionTime(dimension)) {
+  if (timeDimension) {
     return buildTimeDimensionedSessionDurationQuery(params)
   }
 
-  if (dimension) {
+  if (dimensions.length) {
     return buildDimensionedSessionDurationQuery(params)
   }
 
   return buildUndimensionedSessionDurationQuery(params)
 }
 
-function buildTimeDimensionedSessionDurationQuery ({ dimension, startDate, endDate, where }) {
+function buildTimeDimensionedSessionDurationQuery (params) {
+  const {
+    dimensions,
+    timeDimension,
+    nonTimeDimensions = [],
+    where,
+    startDate,
+    endDate,
+    transposeAndAggregate
+  } = params
+  const rawSelect = [`DATE_TRUNC('${timeDimension}', session_end) AS timestamp`].concat(nonTimeDimensions).join(', ')
+  const rawGroupBy = [`DATE_TRUNC('${timeDimension}', session_end)`].concat(nonTimeDimensions).join(', ')
   return db.avg('session_duration as avg_session_duration')
-    .select(db.raw(`DATE_TRUNC('${dimension}', session_end ) AS timestamp`))
+    .select(db.raw(rawSelect))
     .from(function () {
-      this.select(sessionColumn, db.raw(`(CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(${timestampColumn}), MAX(${timestampColumn})) AS FLOAT) END) AS session_duration`))
+      this.select(sessionColumn, ...nonTimeDimensions, db.raw(`(CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(${timestampColumn}), MAX(${timestampColumn})) AS FLOAT) END) AS session_duration`))
         .max(`${timestampColumn} as session_end`)
         .withSchema(schema)
         .from(table)
         .andWhereRaw(where)
-        .groupBy(sessionColumn)
+        .groupBy(sessionColumn, ...nonTimeDimensions)
     })
-    .groupByRaw(`DATE_TRUNC('${dimension}', session_end)`)
+    .groupByRaw(rawGroupBy)
     .as('ignored_alias')
     .queryContext({
-      timeseries: true,
-      startDate,
-      endDate,
-      interval: dimension,
+      timeseries: {
+        startDate,
+        endDate,
+        interval: timeDimension
+      },
       metric: 'avgSessionDuration',
-      snakeCases: ['avg_session_duration']
+      snakeCases: ['avg_session_duration'],
+      transposeAndAggregate,
+      dimensions,
+      timeDimension
     })
 }
 
-function buildDimensionedSessionDurationQuery ({ dimension, where }) {
+function buildDimensionedSessionDurationQuery ({ dimensions, where, transposeAndAggregate }) {
   return db.avg('session_duration as avg_session_duration')
-    .select(dimension)
+    .select(...dimensions)
     .from(function () {
-      this.select(dimension, sessionColumn, db.raw(`(CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(${timestampColumn}), MAX(${timestampColumn})) AS FLOAT) END) AS session_duration`))
+      this.select(...dimensions, sessionColumn, db.raw(`(CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(${timestampColumn}), MAX(${timestampColumn})) AS FLOAT) END) AS session_duration`))
         .max(`${timestampColumn} as session_end`)
         .withSchema(schema)
         .from(table)
         .andWhereRaw(where)
-        .groupBy(dimension, sessionColumn)
+        .groupBy(...dimensions, sessionColumn)
     })
-    .groupBy(dimension)
+    .groupBy(...dimensions)
     .as('ignored_alias')
     .queryContext({
-      snakeCases: ['avg_session_duration']
+      snakeCases: ['avg_session_duration'],
+      metric: 'avgSessionDuration',
+      dimensions,
+      transposeAndAggregate
     })
 }
 

--- a/lib/query/session.js
+++ b/lib/query/session.js
@@ -5,8 +5,7 @@ const {
         defaultSource = {},
         session: sessionSource
       } = {}
-    } = {},
-    timeDimensions: TIME_DIMENSIONS
+    } = {}
   }
 } = require('config')
 const db = require('../db')
@@ -17,44 +16,71 @@ const {
   timestampColumn
 } = sessionSource || defaultSource
 
-const isDimensionTime = (dimension) => TIME_DIMENSIONS.includes(dimension)
-
 function buildSessionQuery (params = {}) {
-  const { dimension } = params
+  const {
+    dimensions = [],
+    timeDimension
+  } = params
 
-  if (isDimensionTime(dimension)) {
+  if (timeDimension) {
     return buildTimeDimensionedSessionCountQuery(params)
   }
 
-  if (dimension) {
+  if (dimensions.length) {
     return buildDimensionedSessionCountQuery(params)
   }
 
   return buildSessionCountQuery(params)
 }
 
-function buildTimeDimensionedSessionCountQuery ({ dimension, where, startDate, endDate }) {
-  return db.select(db.raw(`DATE_TRUNC('${dimension}', ${timestampColumn} ) AS timestamp, COUNT(DISTINCT ${sessionColumn}) AS sessions`))
+function buildTimeDimensionedSessionCountQuery (params) {
+  const {
+    dimensions,
+    timeDimension,
+    nonTimeDimensions = [],
+    where,
+    startDate,
+    endDate,
+    transposeAndAggregate
+  } = params
+
+  const rawSelect = [
+    `DATE_TRUNC('${timeDimension}', ${timestampColumn} ) AS timestamp`,
+    `COUNT(DISTINCT ${sessionColumn}) AS sessions`
+  ].concat(nonTimeDimensions).join(', ')
+
+  const rawGroupBy = [`DATE_TRUNC('${timeDimension}', ${timestampColumn} )`].concat(nonTimeDimensions).join(', ')
+
+  return db.select(db.raw(rawSelect))
     .withSchema(schema)
     .from(table)
     .andWhereRaw(where)
-    .groupByRaw(`DATE_TRUNC('${dimension}', ${timestampColumn} )`)
-    .orderByRaw(`DATE_TRUNC('${dimension}', ${timestampColumn} )`)
+    .groupByRaw(rawGroupBy)
+    .orderByRaw(`DATE_TRUNC('${timeDimension}', ${timestampColumn} )`)
     .queryContext({
-      timeseries: true,
-      startDate,
-      endDate,
-      interval: dimension,
-      metric: 'sessions'
+      timeseries: {
+        startDate,
+        endDate,
+        interval: timeDimension
+      },
+      metric: 'sessions',
+      dimensions,
+      timeDimension,
+      transposeAndAggregate
     })
 }
 
-function buildDimensionedSessionCountQuery ({ dimension, where }) {
-  return db.select(dimension, db.raw(`COUNT(DISTINCT ${sessionColumn}) AS sessions`))
+function buildDimensionedSessionCountQuery ({ dimensions, where, transposeAndAggregate }) {
+  return db.select(...dimensions, db.raw(`COUNT(DISTINCT ${sessionColumn}) AS sessions`))
     .withSchema(schema)
     .from(table)
     .andWhereRaw(where)
-    .groupBy(dimension)
+    .groupBy(...dimensions)
+    .queryContext({
+      metric: 'sessions',
+      dimensions,
+      transposeAndAggregate
+    })
 }
 
 function buildSessionCountQuery ({ where }) {

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -1,8 +1,10 @@
+const _ = require('lodash')
 const Joi = require('joi')
 const {
   koopProviderRedshiftAnalytics: {
     metrics: METRICS,
-    dimensions: DIMENSIONS
+    dimensions: DIMENSIONS,
+    timeDimensions: TIME_DIMENSIONS
   }
 } = require('config')
 const time = require('./time')
@@ -11,7 +13,20 @@ const customJoi = Joi.extend(time).extend(where)
 
 const schema = customJoi.object({
   metric: Joi.string().valid(...METRICS).required(),
-  dimension: Joi.string().valid(...DIMENSIONS).default(null),
+  dimensions: Joi.array()
+    .items(Joi.string().valid(...DIMENSIONS))
+    .when('transposeAndAggregate', {
+      is: Joi.exist(),
+      then: Joi.array().length(2)
+    })
+    .error((errors) => {
+      if (_.get(errors, '[0].code') === 'array.length') {
+        return new Error('Must have exactly two dimensions to transpose and aggregate')
+      }
+      return errors
+    })
+    .optional(),
+  transposeAndAggregate: Joi.boolean().valid(true).optional(),
   time: customJoi.time(),
   where: customJoi.where()
 })
@@ -23,9 +38,45 @@ const paramsSchema = {
       time = 'null,null',
       where
     } = value
-    const [metric, dimension] = id.split(':')
-    return schema.validate({ metric, dimension, time, where })
+    const { metric, dimensions, options } = parseIdParam(id)
+    const result = schema.validate({ metric, dimensions, time, where, ...options })
+    if (result.error) return result
+
+    return postProcess(result)
   }
 }
 
+function postProcess ({ value }) {
+  const { dimensions, time, ...rest } = value
+  if (!dimensions) {
+    return { value: { ...rest, ...time } }
+  }
+  const parsedDimensions = parseDimensions(value.dimensions)
+  return { value: { ...rest, dimensions, ...parsedDimensions, ...time } }
+}
+
+function parseIdParam (id) {
+  const idRegex = /^(?<metric>[^:]+)(:)?((?<delimitedDimensions>[^~]+)(~?)(?<delimitedOptions>.+)?)?$/
+  const { groups: { metric, delimitedDimensions, delimitedOptions } } = idRegex.exec(id)
+  const dimensions = delimitedDimensions ? delimitedDimensions.split(',') : undefined
+  const options = delimitedOptions ? parseOptions(delimitedOptions) : undefined
+  return { metric, dimensions, options }
+}
+
+function parseDimensions (dimensions) {
+  const timeDimension = dimensions.find(dimension => TIME_DIMENSIONS.includes(dimension))
+  const nonTimeDimensions = _.difference(dimensions, [timeDimension])
+  return {
+    timeDimension,
+    nonTimeDimensions: nonTimeDimensions.length > 0 ? nonTimeDimensions : undefined
+  }
+}
+
+function parseOptions (delimitedOptions) {
+  return _.chain(delimitedOptions)
+    .split(',')
+    .map(key => { return [key, true] })
+    .fromPairs()
+    .value()
+}
 module.exports = { paramsSchema }

--- a/test/lib/db/transpose-and-aggregate-by-dimensions.test.js
+++ b/test/lib/db/transpose-and-aggregate-by-dimensions.test.js
@@ -1,0 +1,51 @@
+/* eslint-env mocha */
+const chai = require('chai')
+const expect = chai.expect
+const transposeAndAggregateByDimensions = require('../../../lib/db/transpose-and-aggregate-by-dimensions')
+
+describe('transposeAndAggregateByDimesnions', () => {
+  it('should transpose and aggregate with time-dimension as aggregation key', () => {
+    const data = [
+      { timestamp: new Date(2020, 1, 1), userType: 'admin', pageViews: '100' },
+      { timestamp: new Date(2020, 1, 1), userType: 'member', pageViews: '51' },
+      { timestamp: new Date(2020, 1, 2), userType: 'admin', pageViews: '99' },
+      { timestamp: new Date(2020, 1, 2), userType: 'public', pageViews: '21' }
+    ]
+
+    const result = transposeAndAggregateByDimensions({ data, metric: 'pageViews', dimensions: ['userType', 'day'], timeDimension: 'day' })
+    expect(result).to.deep.equal([
+      { timestamp: new Date(2020, 1, 1), admin: 100, member: 51, public: 0 },
+      { timestamp: new Date(2020, 1, 2), admin: 99, member: 0, public: 21 }
+    ])
+  })
+
+  it('should transpose and aggregate with non-time-dimension as aggregation key', () => {
+    const data = [
+      { a_hostname: 'hub.com', userType: 'admin', pageViews: '100' },
+      { a_hostname: 'hub.com', userType: 'member', pageViews: '51' },
+      { a_hostname: 'koop.com', userType: 'admin', pageViews: '99' },
+      { a_hostname: 'koop.com', userType: 'public', pageViews: '21' }
+    ]
+
+    const result = transposeAndAggregateByDimensions({ data, metric: 'pageViews', dimensions: ['userType', 'a_hostname'] })
+    expect(result).to.deep.equal([
+      { a_hostname: 'hub.com', admin: 100, member: 51, public: 0 },
+      { a_hostname: 'koop.com', admin: 99, member: 0, public: 21 }
+    ])
+  })
+
+  it('should transpose and aggregate and handle empty strings', () => {
+    const data = [
+      { a_hostname: 'hub.com', userType: '', pageViews: '100' },
+      { a_hostname: 'hub.com', userType: 'member', pageViews: '51' },
+      { a_hostname: 'koop.com', userType: 'admin', pageViews: '99' },
+      { a_hostname: 'koop.com', userType: 'public', pageViews: '21' }
+    ]
+
+    const result = transposeAndAggregateByDimensions({ data, metric: 'pageViews', dimensions: ['userType', 'a_hostname'] })
+    expect(result).to.deep.equal([
+      { a_hostname: 'hub.com', admin: 0, emptyString: 100, member: 51, public: 0 },
+      { a_hostname: 'koop.com', admin: 99, emptyString: 0, member: 0, public: 21 }
+    ])
+  })
+})

--- a/test/lib/query/event.test.js
+++ b/test/lib/query/event.test.js
@@ -26,17 +26,26 @@ const buildEventQuery = proxyquire(modulePath, {
 
 describe('event query builder', () => {
   it('should build a non-dimensioned event count query', () => {
-    const query = buildEventQuery({ metric: 'pageViews', time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
+    const buildEventQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildEventQuery({ metric: 'pageViews', startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select count("event-column") as "page_views" from "redshift-schema"."analytics-table" where "event-column" = \'pageView\' and raw-where-clause')
   })
 
   it('should build a timestamp-dimensioned event count query', () => {
-    const query = buildEventQuery({ metric: 'pageViews', dimension: 'day', time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
+    const buildEventQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildEventQuery({ metric: 'pageViews', timeDimension: 'day', nonTimeDimensions: [], dimensions: ['day'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select DATE_TRUNC(\'day\', timestamp-column ) AS timestamp, count("event-column") as "page_views" from "redshift-schema"."analytics-table" where "event-column" = \'pageView\' and raw-where-clause group by DATE_TRUNC(\'day\', timestamp-column ) order by DATE_TRUNC(\'day\', timestamp-column )')
   })
 
   it('should build a non-timestamp-dimensioned event count query', () => {
-    const query = buildEventQuery({ metric: 'pageViews', dimension: 'a_label', time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
+    const buildEventQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildEventQuery({ metric: 'pageViews', dimensions: ['a_label'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select "a_label", count("event-column") as "page_views" from "redshift-schema"."analytics-table" where "event-column" = \'pageView\' and raw-where-clause group by "a_label"')
   })
 })

--- a/test/lib/query/event.test.js
+++ b/test/lib/query/event.test.js
@@ -3,26 +3,24 @@ const chai = require('chai')
 const proxyquire = require('proxyquire')
 const expect = chai.expect
 const modulePath = '../../../lib/query/event'
-const buildEventQuery = proxyquire(modulePath, {
-  config: {
-    koopProviderRedshiftAnalytics: {
-      redshift: {
-        sources: {
-          event: {
-            schema: 'redshift-schema',
-            table: 'analytics-table',
-            eventColumn: 'event-column',
-            timestampColumn: 'timestamp-column'
-          }
+const configStub = {
+  koopProviderRedshiftAnalytics: {
+    redshift: {
+      sources: {
+        event: {
+          schema: 'redshift-schema',
+          table: 'analytics-table',
+          eventColumn: 'event-column',
+          timestampColumn: 'timestamp-column'
         }
-      },
-      timeDimensions: ['day'],
-      eventLookup: {
-        pageViews: 'pageView'
       }
+    },
+    timeDimensions: ['day'],
+    eventLookup: {
+      pageViews: 'pageView'
     }
   }
-})
+}
 
 describe('event query builder', () => {
   it('should build a non-dimensioned event count query', () => {

--- a/test/lib/query/session-duration.test.js
+++ b/test/lib/query/session-duration.test.js
@@ -24,23 +24,23 @@ describe('session-duration query builder', () => {
     const buildSessionDurationQuery = proxyquire(modulePath, {
       config: configStub
     })
-    const query = buildSessionDurationQuery({ time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
+    const query = buildSessionDurationQuery({ startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select avg("session_duration") as "avg_session_duration" from (select "session-column", (CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(timestamp-column), MAX(timestamp-column)) AS FLOAT) END) AS session_duration, max("timestamp-column") as "session_end" from "redshift-schema"."analytics-table" where raw-where-clause group by "session-column")')
   })
 
-  it('should build a timestamp-dimensioned session duration query', () => {
+  it('should build a time-dimensioned session duration query', () => {
     const buildSessionDurationQuery = proxyquire(modulePath, {
       config: configStub
     })
-    const query = buildSessionDurationQuery({ dimension: 'day', time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
-    expect(query.toString()).to.equal('select avg("session_duration") as "avg_session_duration", DATE_TRUNC(\'day\', session_end ) AS timestamp from (select "session-column", (CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(timestamp-column), MAX(timestamp-column)) AS FLOAT) END) AS session_duration, max("timestamp-column") as "session_end" from "redshift-schema"."analytics-table" where raw-where-clause group by "session-column") group by DATE_TRUNC(\'day\', session_end)')
+    const query = buildSessionDurationQuery({ timeDimension: 'day', dimensions: ['day'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
+    expect(query.toString()).to.equal('select avg("session_duration") as "avg_session_duration", DATE_TRUNC(\'day\', session_end) AS timestamp from (select "session-column", (CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(timestamp-column), MAX(timestamp-column)) AS FLOAT) END) AS session_duration, max("timestamp-column") as "session_end" from "redshift-schema"."analytics-table" where raw-where-clause group by "session-column") group by DATE_TRUNC(\'day\', session_end)')
   })
 
-  it('should build a non-timestamp-dimensioned session duration query', () => {
+  it('should build a non-time-dimensioned session duration query', () => {
     const buildSessionDurationQuery = proxyquire(modulePath, {
       config: configStub
     })
-    const query = buildSessionDurationQuery({ dimension: 'a_hostname', time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
+    const query = buildSessionDurationQuery({ dimensions: ['a_hostname'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select avg("session_duration") as "avg_session_duration", "a_hostname" from (select "a_hostname", "session-column", (CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(timestamp-column), MAX(timestamp-column)) AS FLOAT) END) AS session_duration, max("timestamp-column") as "session_end" from "redshift-schema"."analytics-table" where raw-where-clause group by "a_hostname", "session-column") group by "a_hostname"')
   })
 })

--- a/test/lib/query/session.test.js
+++ b/test/lib/query/session.test.js
@@ -24,7 +24,7 @@ describe('session query builder', () => {
     const buildSessionQuery = proxyquire(modulePath, {
       config: configStub
     })
-    const query = buildSessionQuery({ time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
+    const query = buildSessionQuery({ startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select COUNT(DISTINCT session-column) AS sessions from "redshift-schema"."analytics-table" where raw-where-clause')
   })
 
@@ -32,7 +32,7 @@ describe('session query builder', () => {
     const buildSessionQuery = proxyquire(modulePath, {
       config: configStub
     })
-    const query = buildSessionQuery({ dimension: 'day', time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
+    const query = buildSessionQuery({ timeDimension: 'day', dimensions: ['day'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select DATE_TRUNC(\'day\', timestamp-column ) AS timestamp, COUNT(DISTINCT session-column) AS sessions from "redshift-schema"."analytics-table" where raw-where-clause group by DATE_TRUNC(\'day\', timestamp-column ) order by DATE_TRUNC(\'day\', timestamp-column )')
   })
 
@@ -40,7 +40,7 @@ describe('session query builder', () => {
     const buildSessionQuery = proxyquire(modulePath, {
       config: configStub
     })
-    const query = buildSessionQuery({ dimension: 'a_label', time: { startDate: 'START', endDate: 'END' }, where: 'raw-where-clause' })
+    const query = buildSessionQuery({ dimensions: ['a_label'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select "a_label", COUNT(DISTINCT session-column) AS sessions from "redshift-schema"."analytics-table" where raw-where-clause group by "a_label"')
   })
 })

--- a/test/schema/index.test.js
+++ b/test/schema/index.test.js
@@ -1,32 +1,73 @@
 /* eslint-env mocha */
 const chai = require('chai')
 const expect = chai.expect
-const { paramsSchema } = require('../../lib/schema')
+const proxyquire = require('proxyquire')
+const modulePath = '../../lib/schema'
+const iso8601Regex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/
+const configStub = {
+  'config': { // eslint-disable-line
+    koopProviderRedshiftAnalytics: {
+      metrics: ['pageViews'],
+      dimensions: ['day', 'userType'],
+      timeDimensions: ['day']
+    }
+  }
+}
+const { paramsSchema } = proxyquire(modulePath, configStub)
 
 describe('schema', function () {
   it('should reject invalid metric param', () => {
     const { error } = paramsSchema.validate({ id: 'unsupported' })
-    expect(error).to.have.property('message', '"metric" must be one of [pageViews, sessions, avgSessionDuration]')
+    expect(typeof error).to.equal('object')
   })
 
-  it('should allow metric params', () => {
-    ['pageViews', 'sessions', 'avgSessionDuration'].forEach(metric => {
-      const { error, value } = paramsSchema.validate({ id: metric })
-      expect(error).to.be.an('undefined')
-      expect(value).to.have.property('dimension', null)
-      expect(value).to.have.property('metric', metric)
-    })
+  it('should validate metric-only id param', () => {
+    const { error, value } = paramsSchema.validate({ id: 'pageViews' })
+    expect(error).to.be.an('undefined')
+    expect(value).to.have.property('metric', 'pageViews')
+    expect(value).to.have.property('where', undefined)
+    expect(value).to.have.property('startDate')
+    expect(iso8601Regex.test(value.startDate)).to.equal(true)
+    expect(value).to.have.property('endDate')
+    expect(iso8601Regex.test(value.endDate)).to.equal(true)
   })
 
-  it('should reject invalid dimension param', () => {
+  it('should reject invalid dimensions param', () => {
     const { error } = paramsSchema.validate({ id: 'pageViews:unsupported' })
-    expect(error).to.have.property('message', '"dimension" must be [day]')
+    expect(typeof error).to.equal('object')
   })
 
-  it('should allow valid dimension param', () => {
+  it('should validate simple dimensions param', () => {
     const { error, value } = paramsSchema.validate({ id: 'pageViews:day' })
     expect(error).to.be.an('undefined')
-    expect(value).to.have.property('dimension', 'day')
+    expect(value).to.have.property('dimensions')
+    expect(value.dimensions).to.deep.equal(['day'])
     expect(value).to.have.property('metric', 'pageViews')
+  })
+
+  it('should validate delimited dimensions param', () => {
+    const { error, value } = paramsSchema.validate({ id: 'pageViews:day,userType' })
+    expect(error).to.be.an('undefined')
+    expect(value).to.have.property('dimensions')
+    expect(value.dimensions).to.deep.equal(['day', 'userType'])
+    expect(value.timeDimension).to.equal('day')
+    expect(value.nonTimeDimensions).to.deep.equal(['userType'])
+    expect(value).to.have.property('metric', 'pageViews')
+  })
+
+  it('should validate delimited dimensions param with transposeAndAggregate option', () => {
+    const { error, value } = paramsSchema.validate({ id: 'pageViews:day,userType~transposeAndAggregate' })
+    expect(error).to.be.an('undefined')
+    expect(value).to.have.property('dimensions')
+    expect(value.dimensions).to.deep.equal(['day', 'userType'])
+    expect(value.timeDimension).to.equal('day')
+    expect(value.nonTimeDimensions).to.deep.equal(['userType'])
+    expect(value.transposeAndAggregate).to.equal(true)
+    expect(value).to.have.property('metric', 'pageViews')
+  })
+
+  it('should reject single dimensions param with transposeAndAggregate option', () => {
+    const { error } = paramsSchema.validate({ id: 'pageViews:day~transposeAndAggregate' })
+    expect(error).to.have.property('message', 'Must have exactly two dimensions to transpose and aggregate')
   })
 })


### PR DESCRIPTION
See TP https://esriarlington.tpondemand.com/entity/156641-recreate-pageviews-by-usertype-aggregation

This PR adds the ability to transpose and aggregated dimensioned data.  For example, the requested data is dimensioned by `day` and `userType`:

```js
[
      { timestamp: '2020-02-01T08:00:00.000Z', userType: 'admin', pageViews: '100' },
      { timestamp: '2020-02-01T08:00:00.000Z', userType: 'member', pageViews: '51' },
      { timestamp: '2020-02-02T08:00:00.000Z', userType: 'admin', pageViews: '99' },
      { timestamp: '2020-02-02T08:00:00.000Z', userType: 'public', pageViews: '21' }
]
```

But the client wants it *transposed* by `userType` and then *aggregated* by time dimension, e.g.,:

```js
[
      { timestamp: '2020-02-01T08:00:00.000Z', admin: 100, member: 51, public: 0 },
      { timestamp: '2020-02-02T08:00:00.000Z', admin: 99, member: 0, public: 21 }
]
```

For a user to request transposed and aggregated results, they must add the `transposeAndAggregate` option to the path parameter (`:id`).  So for example, the general Feature Service query route that looks like

`/koop-provider-redshift-analytics/:id/FeatureService/0/query`

would look like this for the transpose and aggregate query request:

`/koop-provider-redshift-analytics/pageViews:userType,day~transposeAndAggregate/FeatureService/0/query`

Note that the `id` path parameter is **pageViews:userType,day~transposeAndAggregate** and gets parsed to:

```
metric: 'pageViews',
dimensions: ['userType', 'day'],
transposeAndAggregate: true
```

Also note, that only two dimensions are allowed and that the first is considered the *transpose* dimension and the second is considered the *aggregation* dimension.