### PR TITLE
Allow use of separate table/view for session queries if one is available

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,7 +12,7 @@
           "table": "KOOP_REDSHIFT_TABLE",
           "eventColumn": "KOOP_REDSHIFT_COLUMN_EVENT",
           "sessionColumn": "KOOP_REDSHIFT_COLUMN_SESSION",
-          "timestampColumn": "KOOP_REDSHIFT_COLUMN_TIMESTAMP"
+          "timestampColumn": "KOOP_REDSHIFT_COLUMN_EVENT_TIMESTAMP"
         },
         "event": {
           "schema": "KOOP_REDSHIFT_SCHEMA_EVENT",
@@ -24,6 +24,7 @@
           "schema": "KOOP_REDSHIFT_SCHEMA_SESSION",
           "table": "KOOP_REDSHIFT_TABLE_SESSION",
           "sessionColumn": "KOOP_REDSHIFT_COLUMN_SESSION",
+          "sessionDurationColumn": "KOOP_REDSHIFT_COLUMN_SESSION_DURATION",
           "timestampColumn": "KOOP_REDSHIFT_COLUMN_SESSION_TIMESTAMP"
         }
       }

--- a/config/default.json
+++ b/config/default.json
@@ -2,6 +2,7 @@
   "koopProviderRedshiftAnalytics": {
     "dimensions": ["day", "a_hostname", "a_org"],
     "timeDimensions": ["day"],
+    "sessionDimensions": ["day"],
     "metrics": ["pageViews", "sessions", "avgSessionDuration"],
     "defaultTimeRangeStart": {
       "interval": "day",

--- a/lib/query/helpers/raw-where.js
+++ b/lib/query/helpers/raw-where.js
@@ -24,7 +24,7 @@ module.exports = function buildRawWhere ({ metric, endDate, startDate, where }) 
 
 function getTimestampColumn (metric) {
   if (metric === 'sessions' || metric === 'avgSessionDuration') {
-    return _.get(sessionSource, 'timestamp', defaultSource.timestampColumn)
+    return _.get(sessionSource, 'timestampColumn', defaultSource.timestampColumn)
   }
-  return _.get(eventSource, 'timestamp', defaultSource.timestampColumn)
+  return _.get(eventSource, 'timestampColumn', defaultSource.timestampColumn)
 }

--- a/lib/query/session-duration.js
+++ b/lib/query/session-duration.js
@@ -28,10 +28,7 @@ function buildSessionDurationQuery (params = {}) {
 }
 
 function buildTimeDimensionedQuery (params) {
-  if (sessionSource) {
-    return buildTimeDimensionedQueryFromSessionSource(params)
-  }
-  return buildTimeDimensionedQueryFromDefaultSource(params)
+  return sessionSource ? buildTimeDimensionedQueryFromSessionSource(params) : buildTimeDimensionedQueryFromDefaultSource(params)
 }
 
 function buildTimeDimensionedQueryFromSessionSource (params) {
@@ -114,10 +111,7 @@ function buildTimeDimensionedQueryFromDefaultSource (params) {
 }
 
 function buildDimensionedQuery (params) {
-  if (sessionSource) {
-    return buildDimensionedQueryFromSessionSource(params)
-  }
-  return buildDimensionedQueryFromDefaultSource(params)
+  return sessionSource ? buildDimensionedQueryFromSessionSource(params) : buildDimensionedQueryFromDefaultSource(params)
 }
 
 function buildDimensionedQueryFromSessionSource ({ dimensions, where, transposeAndAggregate }) {
@@ -166,10 +160,7 @@ function buildDimensionedQueryFromDefaultSource ({ dimensions, where, transposeA
 }
 
 function buildUndimensionedQuery ({ where }) {
-  if (sessionSource) {
-    return buildUndimensionedQueryFromSessionSource(where)
-  }
-  return buildUndimensionedQueryFromDefaultSource(where)
+  return sessionSource ? buildUndimensionedQueryFromSessionSource(where) : buildUndimensionedQueryFromDefaultSource(where)
 }
 
 function buildUndimensionedQueryFromSessionSource (where) {

--- a/lib/query/session-duration.js
+++ b/lib/query/session-duration.js
@@ -9,12 +9,6 @@ const {
   }
 } = require('config')
 const db = require('../db')
-const {
-  schema,
-  table,
-  sessionColumn,
-  timestampColumn
-} = sessionSource || defaultSource
 
 function buildSessionDurationQuery (params = {}) {
   const {
@@ -23,17 +17,25 @@ function buildSessionDurationQuery (params = {}) {
   } = params
 
   if (timeDimension) {
-    return buildTimeDimensionedSessionDurationQuery(params)
+    return buildTimeDimensionedQuery(params)
   }
 
   if (dimensions.length) {
-    return buildDimensionedSessionDurationQuery(params)
+    return buildDimensionedQuery(params)
   }
 
-  return buildUndimensionedSessionDurationQuery(params)
+  return buildUndimensionedQuery(params)
 }
 
-function buildTimeDimensionedSessionDurationQuery (params) {
+function buildTimeDimensionedQuery (params) {
+  if (sessionSource) {
+    return buildTimeDimensionedQueryFromSessionSource(params)
+  }
+  return buildTimeDimensionedQueryFromDefaultSource(params)
+}
+
+function buildTimeDimensionedQueryFromSessionSource (params) {
+  const { sessionDurationColumn, timestampColumn, schema, table } = sessionSource
   const {
     dimensions,
     timeDimension,
@@ -43,6 +45,46 @@ function buildTimeDimensionedSessionDurationQuery (params) {
     endDate,
     transposeAndAggregate
   } = params
+  const rawSelect = [`DATE_TRUNC('${timeDimension}', ${timestampColumn}) AS timestamp`].concat(nonTimeDimensions).join(', ')
+  const rawGroupBy = [`DATE_TRUNC('${timeDimension}', ${timestampColumn})`].concat(nonTimeDimensions).join(', ')
+  return db.avg(`${sessionDurationColumn} as avg_session_duration`)
+    .select(db.raw(rawSelect))
+    .withSchema(schema)
+    .from(table)
+    .andWhereRaw(where)
+    .groupByRaw(rawGroupBy)
+    .queryContext({
+      timeseries: {
+        startDate,
+        endDate,
+        interval: timeDimension
+      },
+      metric: 'avgSessionDuration',
+      snakeCases: ['avg_session_duration'],
+      transposeAndAggregate,
+      dimensions,
+      timeDimension
+    })
+}
+
+function buildTimeDimensionedQueryFromDefaultSource (params) {
+  const {
+    schema,
+    table,
+    sessionColumn,
+    timestampColumn
+  } = defaultSource
+
+  const {
+    dimensions,
+    timeDimension,
+    nonTimeDimensions = [],
+    where,
+    startDate,
+    endDate,
+    transposeAndAggregate
+  } = params
+
   const rawSelect = [`DATE_TRUNC('${timeDimension}', session_end) AS timestamp`].concat(nonTimeDimensions).join(', ')
   const rawGroupBy = [`DATE_TRUNC('${timeDimension}', session_end)`].concat(nonTimeDimensions).join(', ')
   return db.avg('session_duration as avg_session_duration')
@@ -71,7 +113,38 @@ function buildTimeDimensionedSessionDurationQuery (params) {
     })
 }
 
-function buildDimensionedSessionDurationQuery ({ dimensions, where, transposeAndAggregate }) {
+function buildDimensionedQuery (params) {
+  if (sessionSource) {
+    return buildDimensionedQueryFromSessionSource(params)
+  }
+  return buildDimensionedQueryFromDefaultSource(params)
+}
+
+function buildDimensionedQueryFromSessionSource ({ dimensions, where, transposeAndAggregate }) {
+  const { sessionDurationColumn, schema, table } = sessionSource
+
+  return db.avg(`${sessionDurationColumn} as avg_session_duration`)
+    .select(...dimensions)
+    .withSchema(schema)
+    .from(table)
+    .andWhereRaw(where)
+    .groupBy(...dimensions)
+    .queryContext({
+      snakeCases: ['avg_session_duration'],
+      metric: 'avgSessionDuration',
+      dimensions,
+      transposeAndAggregate
+    })
+}
+
+function buildDimensionedQueryFromDefaultSource ({ dimensions, where, transposeAndAggregate }) {
+  const {
+    schema,
+    table,
+    sessionColumn,
+    timestampColumn
+  } = defaultSource
+
   return db.avg('session_duration as avg_session_duration')
     .select(...dimensions)
     .from(function () {
@@ -92,7 +165,32 @@ function buildDimensionedSessionDurationQuery ({ dimensions, where, transposeAnd
     })
 }
 
-function buildUndimensionedSessionDurationQuery ({ where }) {
+function buildUndimensionedQuery ({ where }) {
+  if (sessionSource) {
+    return buildUndimensionedQueryFromSessionSource(where)
+  }
+  return buildUndimensionedQueryFromDefaultSource(where)
+}
+
+function buildUndimensionedQueryFromSessionSource (where) {
+  const { sessionDurationColumn, schema, table } = sessionSource
+  return db.avg(`${sessionDurationColumn} as avg_session_duration`)
+    .withSchema(schema)
+    .from(table)
+    .andWhereRaw(where)
+    .queryContext({
+      snakeCases: ['avg_session_duration']
+    })
+}
+
+function buildUndimensionedQueryFromDefaultSource (where) {
+  const {
+    schema,
+    table,
+    sessionColumn,
+    timestampColumn
+  } = defaultSource
+
   return db.avg('session_duration as avg_session_duration')
     .from(function () {
       this.select(sessionColumn, db.raw(`(CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(${timestampColumn}), MAX(${timestampColumn})) AS FLOAT) END) AS session_duration`))

--- a/lib/query/session.js
+++ b/lib/query/session.js
@@ -16,6 +16,8 @@ const {
   timestampColumn
 } = sessionSource || defaultSource
 
+const selectSession = sessionSource ? 'COUNT(*) AS sessions' : `COUNT(DISTINCT ${sessionColumn}) AS sessions`
+
 function buildSessionQuery (params = {}) {
   const {
     dimensions = [],
@@ -46,7 +48,7 @@ function buildTimeDimensionedSessionCountQuery (params) {
 
   const rawSelect = [
     `DATE_TRUNC('${timeDimension}', ${timestampColumn} ) AS timestamp`,
-    `COUNT(DISTINCT ${sessionColumn}) AS sessions`
+    selectSession
   ].concat(nonTimeDimensions).join(', ')
 
   const rawGroupBy = [`DATE_TRUNC('${timeDimension}', ${timestampColumn} )`].concat(nonTimeDimensions).join(', ')
@@ -71,7 +73,7 @@ function buildTimeDimensionedSessionCountQuery (params) {
 }
 
 function buildDimensionedSessionCountQuery ({ dimensions, where, transposeAndAggregate }) {
-  return db.select(...dimensions, db.raw(`COUNT(DISTINCT ${sessionColumn}) AS sessions`))
+  return db.select(...dimensions, db.raw(selectSession))
     .withSchema(schema)
     .from(table)
     .andWhereRaw(where)
@@ -85,7 +87,7 @@ function buildDimensionedSessionCountQuery ({ dimensions, where, transposeAndAgg
 
 function buildSessionCountQuery ({ where }) {
   return db
-    .select(db.raw(`COUNT(DISTINCT ${sessionColumn}) AS sessions`))
+    .select(db.raw(selectSession))
     .withSchema(schema)
     .from(table)
     .andWhereRaw(where)

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -4,7 +4,8 @@ const {
   koopProviderRedshiftAnalytics: {
     metrics: METRICS,
     dimensions: DIMENSIONS,
-    timeDimensions: TIME_DIMENSIONS
+    timeDimensions: TIME_DIMENSIONS,
+    sessionDimensions: SESSION_DIMENSIONS
   }
 } = require('config')
 const time = require('./time')
@@ -14,7 +15,13 @@ const customJoi = Joi.extend(time).extend(where)
 const schema = customJoi.object({
   metric: Joi.string().valid(...METRICS).required(),
   dimensions: Joi.array()
-    .items(Joi.string().valid(...DIMENSIONS))
+    .when('metric', {
+      switch: [
+        { is: 'sessions', then: Joi.array().items(Joi.string().valid(...SESSION_DIMENSIONS)) },
+        { is: 'avgSessionDuration', then: Joi.array().items(Joi.string().valid(...SESSION_DIMENSIONS)) }
+      ],
+      otherwise: Joi.array().items(Joi.string().valid(...DIMENSIONS))
+    })
     .when('transposeAndAggregate', {
       is: Joi.exist(),
       then: Joi.array().length(2)

--- a/test/lib/query/helpers/raw-where.test.js
+++ b/test/lib/query/helpers/raw-where.test.js
@@ -4,39 +4,74 @@ const expect = chai.expect
 const proxyquire = require('proxyquire').noCallThru()
 const modulePath = '../../../../lib/query/helpers/raw-where'
 const _ = require('lodash')
-const configStub = {
-  koopProviderRedshiftAnalytics: {
-    redshift: {
-      sources: {
-        defaultSource: {
-          timestampColumn: 'default-timestamp-column'
+
+describe('buildRawWhere', () => {
+  describe('using default source', () => {
+    const configStub = {
+      koopProviderRedshiftAnalytics: {
+        redshift: {
+          sources: {
+            defaultSource: {
+              timestampColumn: 'default-timestamp-column'
+            }
+          }
         }
       }
     }
-  }
-}
+    it('should build where clause for session metric with default source', () => {
+      const buildRawWhere = proxyquire(modulePath, { config: configStub })
+      const result = buildRawWhere({ metric: 'sessions', startDate: 'START_DATE', endDate: 'END_DATE', where: '1 = 2' })
+      expect(result).to.equal('default-timestamp-column > \'START_DATE\' AND default-timestamp-column <= \'END_DATE\' AND 1 = 2')
+    })
 
-describe('buildRawWhere', () => {
-  it('should build where clause for session metric with default source', () => {
-    const buildRawWhere = proxyquire(modulePath, { config: configStub })
-    const result = buildRawWhere({ metric: 'sessions', startDate: 'START_DATE', endDate: 'END_DATE', where: '1 = 2' })
-    expect(result).to.equal('default-timestamp-column > \'START_DATE\' AND default-timestamp-column <= \'END_DATE\' AND 1 = 2')
-  })
-
-  it('should build where clause for event metric with default source', () => {
-    const buildRawWhere = proxyquire(modulePath, { config: configStub })
-    const result = buildRawWhere({ metric: 'event', startDate: 'START_DATE', endDate: 'END_DATE', where: '1 = 2' })
-    expect(result).to.equal('default-timestamp-column > \'START_DATE\' AND default-timestamp-column <= \'END_DATE\' AND 1 = 2')
+    it('should build where clause for event metric with default source', () => {
+      const buildRawWhere = proxyquire(modulePath, { config: configStub })
+      const result = buildRawWhere({ metric: 'event', startDate: 'START_DATE', endDate: 'END_DATE', where: '1 = 2' })
+      expect(result).to.equal('default-timestamp-column > \'START_DATE\' AND default-timestamp-column <= \'END_DATE\' AND 1 = 2')
+    })
   })
 
   it('should build where clause for session metric with session source', () => {
-    _.set(configStub, 'koopProviderRedshiftAnalytics.redshift.sources.session.timestamp', 'session-timestamp-column')
+    const configStub = {
+      koopProviderRedshiftAnalytics: {
+        redshift: {
+          sources: {
+            defaultSource: {
+              timestampColumn: 'default-timestamp-column'
+            },
+            session: {
+              timestampColumn: 'session-timestamp-column'
+            },
+            event: {
+              timestampColumn: 'event-timestamp-column'
+            }
+          }
+        }
+      }
+    }
     const buildRawWhere = proxyquire(modulePath, { config: configStub })
     const result = buildRawWhere({ metric: 'sessions', startDate: 'START_DATE', endDate: 'END_DATE', where: '1 = 2' })
     expect(result).to.equal('session-timestamp-column > \'START_DATE\' AND session-timestamp-column <= \'END_DATE\' AND 1 = 2')
   })
 
   it('should build where clause for event metric with event source', () => {
+    const configStub = {
+      koopProviderRedshiftAnalytics: {
+        redshift: {
+          sources: {
+            defaultSource: {
+              timestampColumn: 'default-timestamp-column'
+            },
+            session: {
+              timestampColumn: 'session-timestamp-column'
+            },
+            event: {
+              timestampColumn: 'event-timestamp-column'
+            }
+          }
+        }
+      }
+    }
     _.set(configStub, 'koopProviderRedshiftAnalytics.redshift.sources.event.timestamp', 'event-timestamp-column')
     const buildRawWhere = proxyquire(modulePath, { config: configStub })
     const result = buildRawWhere({ metric: 'event', startDate: 'START_DATE', endDate: 'END_DATE', where: '1 = 2' })

--- a/test/lib/query/session-duration.test.js
+++ b/test/lib/query/session-duration.test.js
@@ -3,23 +3,24 @@ const chai = require('chai')
 const proxyquire = require('proxyquire').noCallThru()
 const expect = chai.expect
 const modulePath = '../../../lib/query/session-duration'
-const configStub = {
-  koopProviderRedshiftAnalytics: {
-    redshift: {
-      sources: {
-        session: {
-          schema: 'redshift-schema',
-          table: 'analytics-table',
-          sessionColumn: 'session-column',
-          timestampColumn: 'timestamp-column'
-        }
-      }
-    },
-    timeDimensions: ['day']
-  }
-}
 
-describe('session-duration query builder', () => {
+describe('session-duration query builder target default source', () => {
+  const configStub = {
+    koopProviderRedshiftAnalytics: {
+      redshift: {
+        sources: {
+          defaultSource: {
+            schema: 'redshift-schema',
+            table: 'analytics-table',
+            sessionColumn: 'session-column',
+            timestampColumn: 'timestamp-column'
+          }
+        }
+      },
+      timeDimensions: ['day']
+    }
+  }
+
   it('should build a non-dimensioned session duration query', () => {
     const buildSessionDurationQuery = proxyquire(modulePath, {
       config: configStub
@@ -42,5 +43,47 @@ describe('session-duration query builder', () => {
     })
     const query = buildSessionDurationQuery({ dimensions: ['a_hostname'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select avg("session_duration") as "avg_session_duration", "a_hostname" from (select "a_hostname", "session-column", (CASE WHEN COUNT(*) > 1 THEN CAST(DATEDIFF(second, MIN(timestamp-column), MAX(timestamp-column)) AS FLOAT) END) AS session_duration, max("timestamp-column") as "session_end" from "redshift-schema"."analytics-table" where raw-where-clause group by "a_hostname", "session-column") group by "a_hostname"')
+  })
+})
+
+describe('session-duration query builder targeting session view', () => {
+  const configStub = {
+    koopProviderRedshiftAnalytics: {
+      redshift: {
+        sources: {
+          session: {
+            schema: 'redshift-schema',
+            table: 'session-view',
+            sessionDurationColumn: 'session-duration-column',
+            timestampColumn: 'timestamp-column'
+          }
+        }
+      },
+      timeDimensions: ['day']
+    }
+  }
+
+  it('should build a non-dimensioned session duration query', () => {
+    const buildSessionDurationQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildSessionDurationQuery({ startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
+    expect(query.toString()).to.equal('select avg("session-duration-column") as "avg_session_duration" from "redshift-schema"."session-view" where raw-where-clause')
+  })
+
+  it('should build a time-dimensioned session duration query', () => {
+    const buildSessionDurationQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildSessionDurationQuery({ timeDimension: 'day', dimensions: ['day'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
+    expect(query.toString()).to.equal('select avg("session-duration-column") as "avg_session_duration", DATE_TRUNC(\'day\', timestamp-column) AS timestamp from "redshift-schema"."session-view" where raw-where-clause group by DATE_TRUNC(\'day\', timestamp-column)')
+  })
+
+  it('should build a non-time-dimensioned session duration query', () => {
+    const buildSessionDurationQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildSessionDurationQuery({ dimensions: ['a_hostname'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
+    expect(query.toString()).to.equal('select avg("session-duration-column") as "avg_session_duration", "a_hostname" from "redshift-schema"."session-view" where raw-where-clause group by "a_hostname"')
   })
 })

--- a/test/lib/query/session.test.js
+++ b/test/lib/query/session.test.js
@@ -3,23 +3,23 @@ const chai = require('chai')
 const proxyquire = require('proxyquire').noCallThru()
 const expect = chai.expect
 const modulePath = '../../../lib/query/session'
-const configStub = {
-  koopProviderRedshiftAnalytics: {
-    redshift: {
-      sources: {
-        session: {
-          schema: 'redshift-schema',
-          table: 'analytics-table',
-          sessionColumn: 'session-column',
-          timestampColumn: 'timestamp-column'
-        }
-      }
-    },
-    timeDimensions: ['day']
-  }
-}
 
-describe('session query builder', () => {
+describe('session query builder using default source', () => {
+  const configStub = {
+    koopProviderRedshiftAnalytics: {
+      redshift: {
+        sources: {
+          defaultSource: {
+            schema: 'redshift-schema',
+            table: 'analytics-table',
+            sessionColumn: 'session-column',
+            timestampColumn: 'timestamp-column'
+          }
+        }
+      },
+      timeDimensions: ['day']
+    }
+  }
   it('should build a non-dimensioned session count query', () => {
     const buildSessionQuery = proxyquire(modulePath, {
       config: configStub
@@ -42,5 +42,46 @@ describe('session query builder', () => {
     })
     const query = buildSessionQuery({ dimensions: ['a_label'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
     expect(query.toString()).to.equal('select "a_label", COUNT(DISTINCT session-column) AS sessions from "redshift-schema"."analytics-table" where raw-where-clause group by "a_label"')
+  })
+})
+
+describe('session query builder using session source', () => {
+  const configStub = {
+    koopProviderRedshiftAnalytics: {
+      redshift: {
+        sources: {
+          session: {
+            schema: 'redshift-schema',
+            table: 'session-view',
+            sessionColumn: 'session-column',
+            timestampColumn: 'timestamp-column'
+          }
+        }
+      },
+      timeDimensions: ['day']
+    }
+  }
+  it('should build a non-dimensioned session count query', () => {
+    const buildSessionQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildSessionQuery({ startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
+    expect(query.toString()).to.equal('select COUNT(*) AS sessions from "redshift-schema"."session-view" where raw-where-clause')
+  })
+
+  it('should build a timestamp-dimensioned session count query', () => {
+    const buildSessionQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildSessionQuery({ timeDimension: 'day', dimensions: ['day'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
+    expect(query.toString()).to.equal('select DATE_TRUNC(\'day\', timestamp-column ) AS timestamp, COUNT(*) AS sessions from "redshift-schema"."session-view" where raw-where-clause group by DATE_TRUNC(\'day\', timestamp-column ) order by DATE_TRUNC(\'day\', timestamp-column )')
+  })
+
+  it('should build a non-timestamp-dimensioned session count query', () => {
+    const buildSessionQuery = proxyquire(modulePath, {
+      config: configStub
+    })
+    const query = buildSessionQuery({ dimensions: ['a_label'], startDate: 'START', endDate: 'END', where: 'raw-where-clause' })
+    expect(query.toString()).to.equal('select "a_label", COUNT(*) AS sessions from "redshift-schema"."session-view" where raw-where-clause group by "a_label"')
   })
 })

--- a/test/schema/index.test.js
+++ b/test/schema/index.test.js
@@ -7,8 +7,9 @@ const iso8601Regex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/
 const configStub = {
   'config': { // eslint-disable-line
     koopProviderRedshiftAnalytics: {
-      metrics: ['pageViews'],
+      metrics: ['sessions', 'avgSessionDuration', 'pageViews'],
       dimensions: ['day', 'userType'],
+      sessionDimensions: ['day', 'hostname'],
       timeDimensions: ['day']
     }
   }
@@ -53,6 +54,36 @@ describe('schema', function () {
     expect(value.timeDimension).to.equal('day')
     expect(value.nonTimeDimensions).to.deep.equal(['userType'])
     expect(value).to.have.property('metric', 'pageViews')
+  })
+
+  it('should validate delimited session-metric dimensions param', () => {
+    const { error, value } = paramsSchema.validate({ id: 'sessions:day,hostname' })
+    expect(error).to.be.an('undefined')
+    expect(value).to.have.property('dimensions')
+    expect(value.dimensions).to.deep.equal(['day', 'hostname'])
+    expect(value.timeDimension).to.equal('day')
+    expect(value.nonTimeDimensions).to.deep.equal(['hostname'])
+    expect(value).to.have.property('metric', 'sessions')
+  })
+
+  it('should reject delimited session-metric dimensions param', () => {
+    const { error } = paramsSchema.validate({ id: 'sessions:day,action' })
+    expect(error).to.have.property('message', '"dimensions[1]" must be one of [day, hostname]')
+  })
+
+  it('should validate delimited session-duration-metric dimensions param', () => {
+    const { error, value } = paramsSchema.validate({ id: 'avgSessionDuration:day,hostname' })
+    expect(error).to.be.an('undefined')
+    expect(value).to.have.property('dimensions')
+    expect(value.dimensions).to.deep.equal(['day', 'hostname'])
+    expect(value.timeDimension).to.equal('day')
+    expect(value.nonTimeDimensions).to.deep.equal(['hostname'])
+    expect(value).to.have.property('metric', 'avgSessionDuration')
+  })
+
+  it('should reject delimited session-duration-metric dimensions param', () => {
+    const { error } = paramsSchema.validate({ id: 'avgSessionDuration:day,action' })
+    expect(error).to.have.property('message', '"dimensions[1]" must be one of [day, hostname]')
   })
 
   it('should validate delimited dimensions param with transposeAndAggregate option', () => {


### PR DESCRIPTION
A session table/view is presumed to consist of a single row for each session and a column for session-duration.  This allows simplification of the queries (making them more performant).  So when a session table/view is available, these simplified queries should be used.