### PR TITLE
Refactor time and where validation.

### DIFF
--- a/lib/schema/time.js
+++ b/lib/schema/time.js
@@ -19,9 +19,12 @@ const time = {
       const timeRange = value.replace(/\s/g, '').split(',')
 
       if (!isValidTimeRangeArray(timeRange)) {
-        return helpers.message('"time" param must be a comma delimited string: "<start>,<end>". Use "null", an ISO Date srting, YYYY-MM-DD string, or a unix timestamp')
+        return {
+          errors: [
+            new Error('"time" param must be a comma delimited string: "<start>,<end>". Use "null", an ISO Date srting, YYYY-MM-DD string, or a unix timestamp')
+          ]
+        }
       }
-
       return {
         value: translateTimeRangeArray(timeRange)
       }

--- a/lib/schema/where.js
+++ b/lib/schema/where.js
@@ -1,18 +1,24 @@
 const joi = require('joi')
-const sqlstring = require('sqlstring')
+const { Parser } = require('flora-sql-parser')
+const parser = new Parser()
 const where = {
   type: 'where',
   base: joi.string(),
-  coerce: {
-    from: 'string',
-    method (value, helpers) {
-      if (!value) return
+  validate: (value, helpers) => {
+    if (!value) return
 
-      return {
-        value: sqlstring.escape(value)
-      }
+    try {
+      const sql = `SELECT * FROM t WHERE ${value}`
+      parser.parse(sql)
+    } catch (error) {
+      return { errors: [new Error('"where" parameter is invalid')] }
+    }
+
+    return {
+      value
     }
   }
+
 }
 
 module.exports = where

--- a/package-lock.json
+++ b/package-lock.json
@@ -2879,14 +2879,12 @@
     "flora-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/flora-errors/-/flora-errors-2.0.0.tgz",
-      "integrity": "sha512-Wn2HU65ZlJmnWg28W8pAWRNU0UJeMfqB71DXvosjfs8X72X842maUatavUgEz1q4wT5p9kB7A0J4WtuL/pXj3A==",
-      "dev": true
+      "integrity": "sha512-Wn2HU65ZlJmnWg28W8pAWRNU0UJeMfqB71DXvosjfs8X72X842maUatavUgEz1q4wT5p9kB7A0J4WtuL/pXj3A=="
     },
     "flora-sql-parser": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/flora-sql-parser/-/flora-sql-parser-0.9.4.tgz",
       "integrity": "sha512-rZTAUwVwPoEc400+6bfilZt2VeDQGZvaWiaQgpYP1Mo/lP8hSZaZtxcBpNnk3OJpD4G7QmLLipz3hzK0pRSx7w==",
-      "dev": true,
       "requires": {
         "flora-errors": "^2.0.0",
         "has": "^1.0.3"
@@ -6383,11 +6381,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "sqlstring": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
-      "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg=="
     },
     "ssf": {
       "version": "0.11.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "config": "^3.3.1",
+    "flora-sql-parser": "^0.9.4",
     "joi": "^17.2.1",
     "knex": "^0.21.5",
     "lodash": "^4.17.20",
@@ -16,7 +17,6 @@
     "moment-range": "^4.0.2",
     "pg": "^8.3.3",
     "sinon": "^9.0.3",
-    "sqlstring": "^2.3.2",
     "standard": "^14.3.4"
   },
   "devDependencies": {

--- a/test/schema/time.test.js
+++ b/test/schema/time.test.js
@@ -12,27 +12,18 @@ function getDayRange (start, end) {
 
 describe('timeValidation', () => {
   it('should reject invalid range: "null"', () => {
-    coerceTime('null', {
-      message: (msg) => {
-        expect(msg).to.equal('"time" param must be a comma delimited string: "<start>,<end>". Use "null", an ISO Date srting, YYYY-MM-DD string, or a unix timestamp')
-      }
-    })
+    const { errors: [error] } = coerceTime('null')
+    expect(error).to.have.property('message', '"time" param must be a comma delimited string: "<start>,<end>". Use "null", an ISO Date srting, YYYY-MM-DD string, or a unix timestamp')
   })
 
   it('should reject invalid range: "2020-01-01"', () => {
-    coerceTime('2020-01-01', {
-      message: (msg) => {
-        expect(msg).to.equal('"time" param must be a comma delimited string: "<start>,<end>". Use "null", an ISO Date srting, YYYY-MM-DD string, or a unix timestamp')
-      }
-    })
+    const { errors: [error] } = coerceTime('2020-01-01')
+    expect(error).to.have.property('message', '"time" param must be a comma delimited string: "<start>,<end>". Use "null", an ISO Date srting, YYYY-MM-DD string, or a unix timestamp')
   })
 
   it('should reject invalid range: "hello,world"', () => {
-    coerceTime('hello,world', {
-      message: (msg) => {
-        expect(msg).to.equal('"time" param must be a comma delimited string: "<start>,<end>". Use "null", an ISO Date srting, YYYY-MM-DD string, or a unix timestamp')
-      }
-    })
+    const { errors: [error] } = coerceTime('hello,world')
+    expect(error).to.have.property('message', '"time" param must be a comma delimited string: "<start>,<end>". Use "null", an ISO Date srting, YYYY-MM-DD string, or a unix timestamp')
   })
 
   it('should coerce "null,null" to default ISO8601 time range', () => {

--- a/test/schema/where.test.js
+++ b/test/schema/where.test.js
@@ -1,0 +1,16 @@
+/* eslint-env mocha */
+const chai = require('chai')
+const expect = chai.expect
+const { validate: validateWhere } = require('../../lib/schema/where')
+
+describe('where validation', () => {
+  it('should reject invalid where', () => {
+    const { errors: [error] } = validateWhere('not valid where')
+    expect(error).to.have.property('message', '"where" parameter is invalid')
+  })
+
+  it('should allow a valid where', () => {
+    const { value } = validateWhere('test=\'foo\'')
+    expect(value).to.equal('test=\'foo\'')
+  })
+})


### PR DESCRIPTION
The PR fixes some problems with query parameter validation.
1) coercion of the time parameter was not properly throwing errors.

2) where parameter validation was escaping special characters in a way that prevented its use in the redshift query.  Here we change by parsing the `where` with a SQL parser and if it fails we reject.